### PR TITLE
[FEAT] 페이지 라우팅 설정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,15 @@
 import "./App.css";
+import Router from './routes/Router';
 import React from "react";
 
 function App() {
+  const userInfo = false;
 
-  return <div>test</div>;
+  return (
+    <>
+      <Router userInfo={userInfo} />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/ProtectedRoutes.jsx
+++ b/src/components/ProtectedRoutes.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = ({ userInfo }) => {
+  if (!userInfo) {
+    // 유저 정보가 없다면 로그인페이지로 이동
+    window.alert("로그인이 필요한 서비스입니다.");
+    return <Navigate to="/login" replace={true} />;
+  }
+
+  // 유저 정보가 있다면 자식 컴포넌트를 보여줌
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,4 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/pages/ActivityRecord.jsx
+++ b/src/pages/ActivityRecord.jsx
@@ -1,0 +1,7 @@
+const ActivityRecord = () => {
+  return (
+    <div>ActivityRecord 페이지입니다.</div>
+  );
+}
+
+export default ActivityRecord;

--- a/src/pages/ApplyRecord.jsx
+++ b/src/pages/ApplyRecord.jsx
@@ -1,0 +1,7 @@
+const ApplyRecord = () => {
+  return (
+    <div>ApplyRecord 페이지입니다.</div>
+  );
+}
+
+export default ApplyRecord;

--- a/src/pages/Community.jsx
+++ b/src/pages/Community.jsx
@@ -1,0 +1,7 @@
+const Community = () => {
+  return (
+    <div>Community 페이지입니다.</div>
+  );
+}
+
+export default Community;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,7 @@
+const Dashboard = () => {
+  return (
+    <div>Dashboard 페이지입니다.</div>
+  );
+}
+
+export default Dashboard;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,0 +1,7 @@
+const Detail = ({type}) => {
+  return (
+    <div>${type} Detail 페이지입니다.</div>
+  );
+}
+
+export default Detail;

--- a/src/pages/FreeCommunity.jsx
+++ b/src/pages/FreeCommunity.jsx
@@ -1,0 +1,7 @@
+const FreeCommunity = () => {
+  return (
+    <div>FreeCommunity 페이지입니다.</div>
+  );
+}
+
+export default FreeCommunity;

--- a/src/pages/GrowthRecord.jsx
+++ b/src/pages/GrowthRecord.jsx
@@ -1,0 +1,7 @@
+const GrowthRecord = () => {
+  return (
+    <div>GrowthRecord 페이지입니다.</div>
+  );
+}
+
+export default GrowthRecord;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,7 @@
+const Login = () => {
+  return (
+    <div>Login 페이지입니다.</div>
+  );
+}
+
+export default Login;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,0 +1,7 @@
+const Main = () => {
+  return (
+    <div>Main 페이지입니다.</div>
+  );
+}
+
+export default Main;

--- a/src/pages/MemberCommunity.jsx
+++ b/src/pages/MemberCommunity.jsx
@@ -1,0 +1,7 @@
+const MemberCommunity = () => {
+  return (
+    <div>MemberCommunity 페이지입니다.</div>
+  );
+}
+
+export default MemberCommunity;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,7 @@
+const MyPage = () => {
+  return (
+    <div>MyPage 페이지입니다.</div>
+  );
+}
+
+export default MyPage;

--- a/src/pages/PortfolioCommunity.jsx
+++ b/src/pages/PortfolioCommunity.jsx
@@ -1,0 +1,7 @@
+const PortfolioCommunity = () => {
+  return (
+    <div>PortfolioCommunity 페이지입니다.</div>
+  );
+}
+
+export default PortfolioCommunity;

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -1,0 +1,7 @@
+const Record = ({type}) => {
+  return (
+    <div>${type} Record 페이지입니다.</div>
+  );
+}
+
+export default Record;

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,7 @@
+const Signup = () => {
+  return (
+    <div>Signup 페이지입니다.</div>
+  );
+}
+
+export default Signup;

--- a/src/pages/TotalCommunity.jsx
+++ b/src/pages/TotalCommunity.jsx
@@ -1,0 +1,7 @@
+const TotalCommunity = () => {
+  return (
+    <div>TotalCommunity 페이지입니다.</div>
+  );
+}
+
+export default TotalCommunity;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,0 +1,66 @@
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import ProtectedRoute from "../components/ProtectedRoutes";
+import Main from "../pages/Main";
+import Login from "../pages/Login";
+import Signup from "../pages/Signup";
+import Dashboard from "../pages/Dashboard";
+import GrowthRecord from "../pages/GrowthRecord";
+import ApplyRecord from "../pages/ApplyRecord";
+import ActivityRecord from "../pages/ActivityRecord";
+import Community from "../pages/Community";
+import TotalCommunity from "../pages/TotalCommunity"
+import FreeCommunity from "../pages/FreeCommunity";
+import MemberCommunity from "../pages/MemberCommunity";
+import PortfolioCommunity from "../pages/PortfolioCommunity";
+import MyPage from "../pages/MyPage";
+
+// 부모 컴포넌트로부터 로그인 여부에 대한 값 받아와서 사용
+const Router = ({userInfo}) => {
+  const routes = [
+    {
+    path: "/",
+    element: <Main />       // 메인홈
+    },
+    {
+      path: "login", 
+      element: <Login />,   // 로그인
+    },
+    {
+      path: "signup",
+      element: <Signup />,  // 회원가입
+    },
+    {
+      path: "user",     // 로그인 이후 이동 가능 페이지
+      element: <ProtectedRoute userInfo={userInfo} />,
+      children: [
+        { path: "dashboard", element: <Dashboard /> },          // 대시보드
+        {
+          path: "growth",                                       // 성장기록
+          element: <GrowthRecord />,
+          children: [
+            { path: "apply", element: <ApplyRecord /> },        // 지원현황
+            { path: "activity", element: <ActivityRecord /> },  // 활동기록
+          ],
+        },
+        {
+          path: "community",                                    // 커뮤니티
+          element: <Community /> ,
+          children: [
+            { path: "total", element: <TotalCommunity /> },         // 전체 게시판
+            { path: "free", element: <FreeCommunity /> },           // 자유 게시판
+            { path: "member", element: <MemberCommunity /> },       // 팀원모집 게시판
+            { path: "portfolio", element: <PortfolioCommunity /> }, // 포트폴리오 게시판
+          ],
+        },
+        { path: "mypage", element: <MyPage /> },                // 마이페이지
+      ],
+    },
+  ];
+
+  const router = createBrowserRouter([...routes]);
+
+  // 구성요소 전달 및 활성화 -> App.jsx로 빼도 괜찮음
+  return <RouterProvider router={router} />;
+};
+
+export default Router;


### PR DESCRIPTION
## ✅ What to do
페이지 컴포넌트 생성 및 라우팅 설정

<br><br>

## 🛠️ Changes in the project
- 페이지 라우팅 기능
- 로그인을 하지 않은 경우 페이지 접근 제한 및 로그인 페이지로 라우팅하도록 설정
- 기록 작성 및 상세 페이지는 컴포넌트 생성만 해놓은 상태

<br><br>

## 🔥 Issues
- 성장기록의 지원현황, 활동기록 페이지에서 기록 작성, 기록 상세 페이지 라우팅
👉 페이지의 기본적인 틀은 같지만 내용이 살짝 다른데, 이걸 props로 전달할건지 아니면 라우팅 과정에서 url로 정보를 넘겨서 params를 사용할건지 생각해볼 필요 있음

<br><br>

## 👀 References
이슈 - #7 
- [RouterProvider와 CreateBrowserRouter
](https://shape-coding.tistory.com/entry/React-%EB%A6%AC%EC%95%A1%ED%8A%B8-%EB%9D%BC%EC%9A%B0%ED%84%B0-RouterProvider%EC%99%80-CreateBrowserRouter)
- 로그인 여부로 페이지 제한 - [Protected Route](https://velog.io/@frontendohs/React%EB%A1%9C-Protected-Router-%EA%B5%AC%EC%84%B1%ED%95%98%EA%B8%B0)
<br><br>
